### PR TITLE
Use shell scripts to upload files to NCBI and EBI EPMC FTP servers

### DIFF
--- a/src/epmc_ftp_upload.sh
+++ b/src/epmc_ftp_upload.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This shell script uploads one file to the EBI EPMC FTP site.
+# Three arguments are required: 1) the FB release number: e.g., 2024_01; 2) the EBI FTP password; 3) the EBI directory.
+
+# FTP details for labslink.ebi.ac.uk
+HOST="193.62.193.162"
+USER="elinks"
+cd /data/build-public-release/fb_$1_reporting/bulk_reports
+
+# FTP login and upload.
+ftp -inv $HOST <<EOF
+user $USER $2
+cd $3
+put epmc-flybase.xml.gz
+bye
+EOF
+
+

--- a/src/epmc_ftp_upload.sh
+++ b/src/epmc_ftp_upload.sh
@@ -7,6 +7,7 @@
 HOST="193.62.193.162"
 USER="elinks"
 cd /data/build-public-release/fb_$1_reporting/bulk_reports
+pwd
 
 # FTP login and upload.
 ftp -inv $HOST <<EOF

--- a/src/ncbi_ftp_upload.sh
+++ b/src/ncbi_ftp_upload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This shell script uploads three files to the NCBI FTP site.
+# Two arguments are required: 1) the FB release number: e.g., 2024_01; 2) the NCBI FTP password.
+
+# FTP details for ftp-private.ncbi.nih.gov
+HOST="130.14.250.6"
+USER="flybase"
+cd /data/build-public-release/fb_$1_reporting/bulk_reports
+
+# FTP login and upload.
+ftp -inv $HOST <<EOF
+user $USER $2
+cd holdings
+ls
+put nt-flybase.xml
+put pm-flybase.xml
+put pr-flybase.xml
+bye
+EOF
+
+

--- a/src/ncbi_ftp_upload.sh
+++ b/src/ncbi_ftp_upload.sh
@@ -7,12 +7,12 @@
 HOST="130.14.250.6"
 USER="flybase"
 cd /data/build-public-release/fb_$1_reporting/bulk_reports
+pwd
 
 # FTP login and upload.
 ftp -inv $HOST <<EOF
 user $USER $2
 cd holdings
-ls
 put nt-flybase.xml
 put pm-flybase.xml
 put pr-flybase.xml


### PR DESCRIPTION
After many unsuccessful attempts at getting GoCD to use the `go` user `.netrc` file, I've taken a different approach using shell scripts (with passwords stored securely in the GoCD environment). These shell scripts have been used successfully to upload the files to FTP servers using a test GoCD pipeline (`Test_FTP_Upload`).