### PR TITLE
DB-943: Provide more specific gene product type in column 12 of GAF for ncRNA genes.

### DIFF
--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -503,7 +503,7 @@ while (
     # and one or more of them may have info for col 8
     # lets set up a sub to do the parsing and then figure out the best way to deal with
     # multiple lines
-    my @cols_7_8 = parse_evidence_bits( $evid, $dbh );
+    my @cols_7_8 = parse_evidence_bits( $fcvt_id, $evid, $dbh );
     # print_log("DEBUG: 3. Parsed evidence bits.");
 
     # start building the line
@@ -751,8 +751,8 @@ sub check4doi {
 # of the FB gene) that should not be reported). All this extra stuff must be
 # stripped out to report a comma-separated list of db:accession strings.
 sub parse_evidence_bits {
-    my $evbit = shift
-      ; # The $evbit corresponds to the evidence_code feature_cvtermprop.value passed to the sub.
+    my $fcvt_id = shift;    # The feature_cvterm_id for the annotation. 
+    my $evbit = shift;      # The evidence_code feature_cvtermprop.value.
     my $dbh = shift;
     my @evlines;
 
@@ -783,7 +783,7 @@ sub parse_evidence_bits {
         }
 
         # Fourth, get the list of xrefs using the get_dbxrefs() subroutine.
-        ( my $col8, my $mismatch ) = get_dbxrefs( $dbxrefs, $dbh, $evc )
+        ( my $col8, my $mismatch ) = get_dbxrefs( $fcvt_id, $dbxrefs, $dbh, $evc )
           if $dbxrefs;
 
         # Fifth, combine the evidence code abbreviation and the xrefs as a
@@ -806,6 +806,7 @@ sub parse_evidence_bits {
 # we should return "FB:FBgn0003268,FB:FBgn0004643",
 # rather than "FB:FBgn0003268,FLYBASE:Zw10" (currently the case).
 sub get_dbxrefs {
+    my $fcvt_id = shift;    # The feature_cvterm_id for the annotation.
     my $inline  = shift;
     my $dbh     = shift;
     my $evc     = shift;
@@ -841,7 +842,7 @@ sub get_dbxrefs {
         if ( $parts[0] =~ /FLYBASE:(.+)/ ) {
             my $symb = $1;
             $symb = decon($symb);
-            print_log("WARNING: Missing Symbol in evidence code line $inline\n")
+            print_log("WARNING: feature_cvterm_id=$fcvt_id: missing symbol in evidence code line: $inline\n")
               unless ($symb);
             if ( $parts[1] =~ /FB:(FBgn[0-9]{7})/ ) {
                 my $fbgn = $1;
@@ -851,14 +852,14 @@ sub get_dbxrefs {
                 $query->bind_param( 2, $fbgn );
                 $query->execute
                   or
-                  print_log("WARNING: Can't execute $stmt FOR $symb:$fbgn");
+                  print_log("WARNING: feature_cvterm_id=$fcvt_id: can't execute $stmt FOR $symb:$fbgn");
                 unless ( $query->rows() > 0 ) {
                     $nomatch = $fbgn . ':' . $symb;
-                    print_log("WARNING: WE HAVE A MISMATCH for $symb:$fbgn");
+                    print_log("WARNING: feature_cvterm_id=$fcvt_id: WE HAVE A MISMATCH for $symb:$fbgn");
                 }
             }
             else {
-                print_log("WARNING: No FBgn provided for $symb in evidence code line");
+                print_log("WARNING: feature_cvterm_id=$fcvt_id: no FBgn provided for $symb in evidence code line: $inline");
             }
         }
     }

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -357,7 +357,7 @@ $promoted_ncrna_gene_type_query->execute or die print_log("Can't query for ncRNA
 while ( my ( $fid, $pgt_value ) = $promoted_ncrna_gene_type_query->fetchrow_array() )
 {
     if ( $ncrna_gene_class_mapping{$pgt_value} ) {
-        $gene_product_types{$fid} = $ncrna_gene_class_mapping{$pgt_value}
+        $gene_product_types{$fid} = $ncrna_gene_class_mapping{$pgt_value};
         $update_gp_type_counter++;
     }
     $result_counter++;

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -335,7 +335,7 @@ my %ncrna_gene_class_mapping = (
     'SO0002127:lncRNA_gene' => 'lncRNA',
     'SO0002182:antisense_lncRNA_gene' => 'lncRNA',
     'SO0002353:sbRNA_gene' => 'sbRNA',
-)
+);
 my $promoted_ncrna_gene_type_query = $dbh->prepare(
     sprintf("
         SELECT DISTINCT f.feature_id, fp.value

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -283,11 +283,11 @@ my $pmid_query = $dbh->prepare(
     )
 );
 
-# Build, in layers, a gene feature_id-keyed hash of gene product types.
 # DB-943: Improve gene product types listed for ncRNA genes.
+# Build, in layers, a gene feature_id-keyed hash of gene product types.
 print_log("INFO: Get gene product types.");
 # 1. Create feature_id-keyed hash of types based on annotated transcripts.
-# This assumes only one transcript type per gene, which is the current restriction.
+#    This assumes one transcript type per gene, the current convention.
 my %gene_product_types;
 my $transcript_type_query = $dbh->prepare(
     sprintf("
@@ -328,6 +328,7 @@ print_log("INFO: Found $trpt_type_counter gene product types for current localiz
 
 # 2. Get more detailed gene product types for some ncRNA genes.
 #    This only works on reporting builds where 'promoted_gene_type' is available.
+#    For a production db, ncRNA genes simply have 'ncRNA' gene product.
 my %ncrna_gene_class_mapping = (
     '@SO0001269:SRP_RNA_gene@' => 'SRP_RNA',
     '@SO0001640:RNase_MRP_RNA_gene@' => 'RNase_MRP_RNA',
@@ -410,7 +411,7 @@ while (
   )
 {
     $rows++;
-    print_log("DEBUG: 1. Start processing row #$rows: feature_cvterm_id=$fcvtid");
+    # print_log("DEBUG: 1. Start processing row #$rows: feature_cvterm_id=$fcvtid");
     my $pseudoflag;
     my $extratabsflag;
 
@@ -584,7 +585,7 @@ while (
     else {
         $line .= "\t";
     }
-    print_log("DEBUG: 11. Filled in col 11: synonyms.");
+    # print_log("DEBUG: 11. Filled in col 11: synonyms.");
 
     # col 12 - determine the gene product type.
     # DB-943: Use more detailed gene product descriptors.
@@ -604,11 +605,11 @@ while (
         }
     }
     $line .= "$gp_type\t";
-    print_log("DEBUG: 12. Filled in col 12: gene product type.");
+    # print_log("DEBUG: 12. Filled in col 12: gene product type.");
 
     # col 13
     $line .= "taxon:$TAX{$orgn}\t";
-    print_log("DEBUG: 13. Filled in col 13: taxon.");
+    # print_log("DEBUG: 13. Filled in col 13: taxon.");
 
     # col 14
     $line .= "$date\t";

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -503,7 +503,7 @@ while (
     # and one or more of them may have info for col 8
     # lets set up a sub to do the parsing and then figure out the best way to deal with
     # multiple lines
-    my @cols_7_8 = parse_evidence_bits( $fcvt_id, $evid, $dbh );
+    my @cols_7_8 = parse_evidence_bits( $fcvtid, $evid, $dbh );
     # print_log("DEBUG: 3. Parsed evidence bits.");
 
     # start building the line
@@ -751,7 +751,7 @@ sub check4doi {
 # of the FB gene) that should not be reported). All this extra stuff must be
 # stripped out to report a comma-separated list of db:accession strings.
 sub parse_evidence_bits {
-    my $fcvt_id = shift;    # The feature_cvterm_id for the annotation. 
+    my $fcvtid = shift;    # The feature_cvterm_id for the annotation. 
     my $evbit = shift;      # The evidence_code feature_cvtermprop.value.
     my $dbh = shift;
     my @evlines;
@@ -783,7 +783,7 @@ sub parse_evidence_bits {
         }
 
         # Fourth, get the list of xrefs using the get_dbxrefs() subroutine.
-        ( my $col8, my $mismatch ) = get_dbxrefs( $fcvt_id, $dbxrefs, $dbh, $evc )
+        ( my $col8, my $mismatch ) = get_dbxrefs( $fcvtid, $dbxrefs, $dbh, $evc )
           if $dbxrefs;
 
         # Fifth, combine the evidence code abbreviation and the xrefs as a
@@ -806,7 +806,7 @@ sub parse_evidence_bits {
 # we should return "FB:FBgn0003268,FB:FBgn0004643",
 # rather than "FB:FBgn0003268,FLYBASE:Zw10" (currently the case).
 sub get_dbxrefs {
-    my $fcvt_id = shift;    # The feature_cvterm_id for the annotation.
+    my $fcvtid = shift;    # The feature_cvterm_id for the annotation.
     my $inline  = shift;
     my $dbh     = shift;
     my $evc     = shift;
@@ -842,7 +842,7 @@ sub get_dbxrefs {
         if ( $parts[0] =~ /FLYBASE:(.+)/ ) {
             my $symb = $1;
             $symb = decon($symb);
-            print_log("WARNING: feature_cvterm_id=$fcvt_id: missing symbol in evidence code line: $inline\n")
+            print_log("WARNING: feature_cvterm_id=$fcvtid: missing symbol in evidence code line: $inline\n")
               unless ($symb);
             if ( $parts[1] =~ /FB:(FBgn[0-9]{7})/ ) {
                 my $fbgn = $1;
@@ -852,14 +852,14 @@ sub get_dbxrefs {
                 $query->bind_param( 2, $fbgn );
                 $query->execute
                   or
-                  print_log("WARNING: feature_cvterm_id=$fcvt_id: can't execute $stmt FOR $symb:$fbgn");
+                  print_log("WARNING: feature_cvterm_id=$fcvtid: can't execute $stmt FOR $symb:$fbgn");
                 unless ( $query->rows() > 0 ) {
                     $nomatch = $fbgn . ':' . $symb;
-                    print_log("WARNING: feature_cvterm_id=$fcvt_id: WE HAVE A MISMATCH for $symb:$fbgn");
+                    print_log("WARNING: feature_cvterm_id=$fcvtid: WE HAVE A MISMATCH for $symb:$fbgn");
                 }
             }
             else {
-                print_log("WARNING: feature_cvterm_id=$fcvt_id: no FBgn provided for $symb in evidence code line: $inline");
+                print_log("WARNING: feature_cvterm_id=$fcvtid: no FBgn provided for $symb in evidence code line: $inline");
             }
         }
     }

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -308,7 +308,7 @@ my $transcript_type_query = $dbh->prepare(
           AND trpt.uniquename ~ '^FBtr[0-9]{7}\$'
           AND trpt.name !~ '-XR\$'
     ")
-)
+);
 my $trpt_type_counter = 0;
 $transcript_type_query->execute or die print_log("Can't query for gene transcript types.");
 while ( my ( $fid, $trpt_type ) = $transcript_type_query->fetchrow_array() )

--- a/src/GA_file_builder2.2.pl
+++ b/src/GA_file_builder2.2.pl
@@ -329,12 +329,12 @@ print_log("INFO: Found $trpt_type_counter gene product types for current localiz
 # 2. Get more detailed gene product types for some ncRNA genes.
 #    This only works on reporting builds where 'promoted_gene_type' is available.
 my %ncrna_gene_class_mapping = (
-    'SO0001269:SRP_RNA_gene' => 'SRP_RNA',
-    'SO0001640:RNase_MRP_RNA_gene' => 'RNase_MRP_RNA',
-    'SO0001639:RNase_P_RNA_gene' => 'RNase_P_RNA',
-    'SO0002127:lncRNA_gene' => 'lncRNA',
-    'SO0002182:antisense_lncRNA_gene' => 'lncRNA',
-    'SO0002353:sbRNA_gene' => 'sbRNA',
+    '@SO0001269:SRP_RNA_gene@' => 'SRP_RNA',
+    '@SO0001640:RNase_MRP_RNA_gene@' => 'RNase_MRP_RNA',
+    '@SO0001639:RNase_P_RNA_gene@' => 'RNase_P_RNA',
+    '@SO0002127:lncRNA_gene@' => 'lncRNA',
+    '@SO0002182:antisense_lncRNA_gene@' => 'lncRNA',
+    '@SO0002353:sbRNA_gene@' => 'sbRNA',
 );
 my $promoted_ncrna_gene_type_query = $dbh->prepare(
     sprintf("


### PR DESCRIPTION
Key changes: 
1. Greater specificity in gene product type values (col 12 of GAF) for ncRNA genes. This greater specificity is possible only with the `promoted_gene_type` values derived for a reporting build. If the updated script is run on a production db, the gene product type will simply be a generic `ncRNA` for ncRNA genes (matching the generic transcript type the genes annotated transcripts). This has been okayed by the GO curator.
2. I've restructured the code to build a gene product type lookup at the beginning of the script, rather than performing a separate query for each gene. This reduces the script's run time from ~3h to ~3m.
3. I've added a bit more info to certain warnings in the log file.

