### PR TITLE
Db 1039

### DIFF
--- a/src/report_fb_synonym.pl
+++ b/src/report_fb_synonym.pl
@@ -68,7 +68,7 @@ push( @{ $fbids{'FBal'} }, "'allele'" );
 push( @{ $fbids{'FBab'} }, "'chromosome_structure_variation'" );
 push( @{ $fbids{'FBba'} }, "'chromosome_structure_variation'" );
 push( @{ $fbids{'FBti'} },
-    "'transposable_element'", "'transposable_element_insertion_site'" );
+    "'transposable_element'", "'transposable_element_insertion_site'", "'insertion_site'" );
 push(
     @{ $fbids{'FBtp'} },
     "'transgenic_transposable_element'",

--- a/src/report_fb_synonym.pl
+++ b/src/report_fb_synonym.pl
@@ -72,6 +72,7 @@ push( @{ $fbids{'FBti'} },
 push(
     @{ $fbids{'FBtp'} },
     "'transgenic_transposable_element'",
+    "'engineered_region'",
     "'natural_transposon'"
 );
 

--- a/src/report_insertion_mapping.pl
+++ b/src/report_insertion_mapping.pl
@@ -65,7 +65,7 @@ print "##insertion_symbol\tFBti#\tgenomic_location\trange\torientation\tpublicat
 
 my $fbtiwc = 'FBti%';
 ## Main driver
-my $iq = $dbh->prepare(sprintf("SELECT i.uniquename, i.name, i.feature_id, cvt.name as ftype from feature i, cvterm cvt where i.type_id = cvt.cvterm_id and i.is_obsolete = 'f' and is_analysis = 'f' and cvt.name in ('transposable_element_insertion_site', 'insertion_site') and uniquename like '%s' ORDER BY i.uniquename",$fbtiwc));
+my $iq = $dbh->prepare(sprintf("SELECT i.uniquename, i.name, i.feature_id, cvt.name as ftype from feature i, cvterm cvt where i.type_id = cvt.cvterm_id and i.is_obsolete = 'f' and is_analysis = 'f' and cvt.name in ('transposable_element_insertion_site', 'insertion_site', 'transposable_element') and uniquename like '%s' ORDER BY i.uniquename",$fbtiwc));
 $iq->execute or die "WARNING: ERROR: Unable to execute TI query\n";
 while (my %ir = %{$iq->fetchrow_hashref}) {
     ## Get estimated & observed cytogenetic locations

--- a/src/report_insertion_mapping.pl
+++ b/src/report_insertion_mapping.pl
@@ -65,7 +65,7 @@ print "##insertion_symbol\tFBti#\tgenomic_location\trange\torientation\tpublicat
 
 my $fbtiwc = 'FBti%';
 ## Main driver
-my $iq = $dbh->prepare(sprintf("SELECT i.uniquename, i.name, i.feature_id, cvt.name as ftype from feature i, cvterm cvt where i.type_id = cvt.cvterm_id and i.is_obsolete = 'f' and is_analysis = 'f' and cvt.name = 'transposable_element_insertion_site' and uniquename like '%s' ORDER BY i.uniquename",$fbtiwc));
+my $iq = $dbh->prepare(sprintf("SELECT i.uniquename, i.name, i.feature_id, cvt.name as ftype from feature i, cvterm cvt where i.type_id = cvt.cvterm_id and i.is_obsolete = 'f' and is_analysis = 'f' and cvt.name in ('transposable_element_insertion_site', 'insertion_site') and uniquename like '%s' ORDER BY i.uniquename",$fbtiwc));
 $iq->execute or die "WARNING: ERROR: Unable to execute TI query\n";
 while (my %ir = %{$iq->fetchrow_hashref}) {
     ## Get estimated & observed cytogenetic locations


### PR DESCRIPTION
Changes for DB-1039 to add missing data for TI{XXXX} style FBtp and FBti entries to output.
(The bug was that the feature.type for these is different in chado from the corresponding 'regular' FBtp and FBti , so needed to add relevant feaure.types).

Changes to report_fb_synonym.pl add:

- TI{XXXX} style FBtp
- TI{XXXX} style FBti

Changes to report_insertion_mapping.pl add:

- TI{XXXX} style FBti

Changes have been tested by running locally against latest reporting and checking that new output has all the old data plus the desired new data.